### PR TITLE
[Feat] FlagFrog의 국가 선택 기능 개선

### DIFF
--- a/FlagQuizSwiftUI/FlagQuizSwiftUI/Resources/Localizable.xcstrings
+++ b/FlagQuizSwiftUI/FlagQuizSwiftUI/Resources/Localizable.xcstrings
@@ -474,6 +474,22 @@
         }
       }
     },
+    "createFrogView.select.country.whatever.your.country" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "You are free to choose whatever your nationality is"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "국적에 관계없이 자유롭게 선택하실 수 있습니다"
+          }
+        }
+      }
+    },
     "createFrogView.shuffle.button.title" : {
       "localizations" : {
         "en" : {
@@ -495,13 +511,29 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Where is my first settlement?"
+            "value" : "Where is FlagFrog's first settlement?"
           }
         },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "내 첫번째 정착지는 어디인가요?"
+            "value" : "지구리의 첫 정착지는 어디인가요?"
+          }
+        }
+      }
+    },
+    "createFrogView.you.can.change.after.using.points" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "You can change it after using the points(EarthCandy) later"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "추후 포인트를 사용하여 변경하실 수 있습니다"
           }
         }
       }

--- a/FlagQuizSwiftUI/FlagQuizSwiftUI/View/OnBoarding/CreateFrogView.swift
+++ b/FlagQuizSwiftUI/FlagQuizSwiftUI/View/OnBoarding/CreateFrogView.swift
@@ -29,6 +29,7 @@ struct CreateFrogView: View {
                     
                     searchACountryView(isPortrait: true)
                     
+                    
                     chooseCountryButton
                 }
                 .padding()
@@ -88,11 +89,17 @@ struct CreateFrogView: View {
 
         }
         .padding()
-        .frame(minHeight: isPortrait ? 360 : nil, maxHeight: 380)
+        .frame(minHeight: isPortrait ? 385 : nil, maxHeight: 390)
         .background(in: RoundedRectangle(cornerRadius: 10, style: .continuous))
     }
     
+    @ViewBuilder
     var chooseCountryButton: some View {
+        Text("createFrogView.you.can.change.after.using.points")
+            .foregroundStyle(.black)
+            .font(.caption2)
+            .fontWeight(.medium)
+            
         Button {
             viewModel.submitCountry()
         } label: {
@@ -117,15 +124,19 @@ struct CreateFrogView: View {
         }
     }
     
+    @ViewBuilder
     var chosenCountry: some View {
         HStack {
             if let selectedCode = viewModel.selectedCode {
+                
                 Text(selectedCode.flagEmoji ?? "")
-                   
+                
                 Text(selectedCode.localizedName ?? "")
+                
                 
             } else {
                 Text("createFrogView.select.country.below.list")
+              
             }
         }
         .font(.subheadline)
@@ -136,6 +147,9 @@ struct CreateFrogView: View {
             .thinMaterial,
             in: RoundedRectangle(cornerRadius: 8, style: .continuous)
         )
+        Text("createFrogView.select.country.whatever.your.country")
+            .font(.caption2)
+            .padding(.vertical, -12)
     }
     
     var countryList: some View {


### PR DESCRIPTION
FlagFrog의 국가 선택 화면에서 몇 가지 개선 사항을 추가하였습니다. 사용자는 이제 지구리의 첫 정착지는 어디인가요? 대신 FlagFrog의 첫 정착지는 어디인가요?라는 더 명확한 메시지를 볼 수 있습니다. 또한, 국적과 상관없이 자유롭게 선택할 수 있다는 안내 메시지도 추가되었습니다.

또한, 포인트(지구 사탕)를 사용한 후에도 국가를 변경할 수 있는 기능이 추가되었습니다. 이제 내 첫번째 정착지는 어디인가요? 대신 추후 포인트를 사용하여 변경하실 수 있습니다 라는 메시지가 표시됩니다.

이 변경 사항은 FlagQuizSwiftUI 프로젝트의 CreateFrogView에서 이루어진 것입니다.